### PR TITLE
fix tests: explicitely requires unittest2 and import 'unittest' from shi...

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,1 @@
+unittest2

--- a/test/setup_module_test.sh
+++ b/test/setup_module_test.sh
@@ -26,6 +26,7 @@ pip install importlib # this is a requirement of shinken itself
 git clone https://github.com/naparuba/shinken.git ~/shinken
 [ -f test/dep_modules.txt ] && setup_submodule
 [ -f requirements.txt ] && pip install -r requirements.txt
+[ -f test/requirements.txt ] && pip install -r test/requirements.txt
 rm ~/shinken/test/test_*.py
 cp test/test_*.py ~/shinken/test/
 [ -d test/etc ] && cp -r test/etc ~/shinken/test/

--- a/test/test_livestatus_db.py
+++ b/test/test_livestatus_db.py
@@ -33,11 +33,10 @@ import shutil
 import time
 import random
 import copy
-import unittest
 
 
 from shinken_modules import ShinkenModulesTest
-from shinken_test import time_hacker
+from shinken_test import time_hacker, unittest
 
 
 from shinken.objects.module import Module


### PR DESCRIPTION
...nken_test.

Since shinken use unittest2 we also requires it for logstore-sqlite tests.
