### PR TITLE
add configuration option to change the `journal_mode`

### DIFF
--- a/etc/modules/logstore_sqlite.cfg
+++ b/etc/modules/logstore_sqlite.cfg
@@ -16,4 +16,16 @@ define module {
     # Defaults to 0 if unset
     #read_only       1 ; Read only logstore
     max_logs_age    3m  ; d = days, w = weeks, m = months, y = years
+
+    # Change default journal mode
+    #
+    # available journal modes are:
+    # delete, truncate, persist, memory, wal, off
+    #
+    # Use wal mode (write-ahead logging) if you are getting database lock issues
+    # https://www.sqlite.org/wal.html
+    #
+    # Check the following link for more information about journal modes
+    # https://www.sqlite.org/pragma.html#pragma_journal_mode
+    journal_mode     truncate
 }


### PR DESCRIPTION
`wal` mode (write-ahead logging) is highly recommended when you get
database lock issues. Although, the `truncate` mode remains as default
option