### PR TITLE
There is data corruption in the module class when multiple threads send requests

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -129,12 +129,6 @@ class LiveStatusLogStoreSqlite(BaseModule):
         self.use_aggressive_sql = (getattr(modconf, 'use_aggressive_sql', '0') == '1')
         self.read_only = (getattr(modconf, 'read_only', '0') == '1')
 
-        # This stack is used to create a full-blown select-statement
-        self.sql_filter_stack = LiveStatusSqlStack()
-        # This stack is used to create a minimal select-statement which
-        # selects only by time >= and time <=
-        self.sql_time_filter_stack = LiveStatusSqlStack()
-
         # Now sleep one second, so that won't get lineno collisions with the last second
         time.sleep(1)
         Logline.lineno = 0
@@ -158,6 +152,12 @@ class LiveStatusLogStoreSqlite(BaseModule):
         # Get no problem for utf8 insert
         self.dbconn.text_factory = str
         self.dbcursor = self.make_cursor()
+
+        # This stack is used to create a full-blown select-statement
+        self.sql_filter_stack = LiveStatusSqlStack()
+        # This stack is used to create a minimal select-statement which
+        # selects only by time >= and time <=
+        self.sql_time_filter_stack = LiveStatusSqlStack()
 
         #self.execute("PRAGMA cache_size = 200000")
 


### PR DESCRIPTION
## Rationale

I found that if mod-livestatus serves multiple requests at the same time because of multithreading, sometimes the queries executed by mod-logstore-sqlite into the underlying SQL engine will be wrong. For instance, we found that sometimes sending an LQL query to mod-livestatus such as

```
GET log
Filter: time >= 1533160800  /* 2018-08-01 22:00:00 */
Filter: time <= 1533247200  /* 2018-08-02 22:00:00 */
```

will result in the following SQL code being executed: `SELECT * FROM 20180801.logs WHERE time >= 1533160800 AND time <= 1533247200;`, but sometimes in the following SQL code being executed: `SELECT * FROM 20180801.logs WHERE 1 = 1`.

## What I found out

After a thoughtful debugging session, I found out that the reason of this is that, when mod-livestatus handles a request in a different thread, it shallow copies the logstore instance that the broker is using, as can be demonstrated by [this copy.copy() call on livestatus_client_thread.py][1]. Because `sql_filter_stack` and `sql_time_filter_stack` are initializated in the `__init__` method of LiveStatusLogStoreSqlite, every LiveStatusClientThread will use the same instance of these variables. 

So if multiple requests are being handled at the same time, it has the nasty (and terrifying) consequence of a request overwriting filters added into the stack by a different thread. If two threads are calling to `add_filter` at the same time, they will add their filters into the same stack instance.

The first thread that finalizes parsing an LQL request and pops the entire filter stack to build the full filter predicate to put in the SQL statement will not only retrieve their own LQL filters, but additionally, the LQL filters of other threads running at that time. That is why I found out that if you execute the same LQL request in multiple threads at the same time, the following SQL statements may be sometimes executed:

* `SELECT * FROM 20180801.logs WHERE time >= X AND time <= Y AND time >= X AND time <= Y AND time >= X AND time <= Y`
* `SELECT * FROM 20180801.logs WHERE 1 = 1`
* `SELECT * FROM 20180801.logs WHERE 1 = 1`

The first SQL statement has the `(time >= X AND time <= Y)` predicate repeated multiple times because the repetitions are actually the LQL filters that should belong to the other two threads that are processing a request. Because those other threads have lost their original filters, when they pop the stack and they find that it's empty, they place the dummy `1 = 1` filter to avoid having a dangling `WHERE` token that would invalidate the SQL statement.

## How I've fixed this

I've moved the initialization of these stacks into the `open()` method of the logstore module. This method is called by mod-livestatus after the request handler is forked and the database is opened, so each thread has their own instance of the stacks, just like each thread has their own cursors pointing to the database, to avoid a possibly illegal situation of having multiple threads pointing to the same SQL connection anyway.

## Other relevant data

As a reference, this is happening on deployments of shinken where the commits of the PR #15 are being applied as well, so maybe this bug was hidden earlier because if the database is locked there is no SQL statement to execute at all.

[1]: https://github.com/shinken-monitoring/mod-livestatus/blob/master/module/livestatus_client_thread.py#L65