### PR TITLE
Compatibility with Python 2.6

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -211,7 +211,7 @@ class LiveStatusLogStoreSqlite(BaseModule):
 
         self.execute("CREATE INDEX IF NOT EXISTS logs_time ON %s (time)" % table_name)
         self.execute("CREATE INDEX IF NOT EXISTS logs_host_name ON %s (host_name)" % table_name)
-        self.execute("PRAGMA journal_mode={}".format(self.journal_mode))
+        self.execute("PRAGMA journal_mode={0}".format(self.journal_mode))
         self.commit()
 
     def commit_and_rotate_log_db(self):


### PR DESCRIPTION
Use syntax `{0}` instead of `{}` in order to keep compatibility with Python 2.6 as the latest Shinken release does.